### PR TITLE
Fix adding items to cart

### DIFF
--- a/models/carts.js
+++ b/models/carts.js
@@ -8,7 +8,7 @@ module.exports = class cartModel {
         this.cartId = parseInt(data.cartId) || null;
         this.userId = parseInt(data.userId) || null;
         this.productId = parseInt(data.productId) || null;
-        this.quantity = parseInt(data.quantity) || 0;
+        this.quantity = parseInt(data.quantity) || 1;
 
     }
 

--- a/models/carts.js
+++ b/models/carts.js
@@ -99,8 +99,22 @@ module.exports = class cartModel {
 
         try{
 
-            const stmt = "INSERT INTO carts_products(cart_id, product_id, quantity) VALUES($1, $2, $3) RETURNING *;";
-            const values = [this.cartId, this.productId, this.quantity];
+            // Check to see if the product is already in the cart
+            const query = "SELECT * FROM carts_products WHERE cart_id = $1 AND product_id = $2";
+            const queryValues = [this.cartId, this.productId];
+
+            let stmt, values;
+
+            const queryResult = await db.query(query, queryValues);
+
+            if(queryResult?.rows?.length){
+                const newQuantity = queryResult.rows[0].quantity + 1;
+                stmt = "UPDATE carts_products SET quantity = $3 WHERE cart_id = $1 and product_id = $2";
+                values = [this.cartId, this.productId, newQuantity]
+            } else {
+                stmt = "INSERT INTO carts_products(cart_id, product_id, quantity) VALUES($1, $2, $3)";
+                values = [this.cartId, this.productId, this.quantity];
+            }
 
             // Run the statement
             const result = await db.query(stmt, values);


### PR DESCRIPTION
By default when adding an item to the cart it sets quantity to 0, it should be 1.

It should alos check if the item is already in the cart and if so update the quantity instead of producing an error.

It should alos bring in the desired qunatity set from the client as well