### PR TITLE
Set search terms to be lower case

### DIFF
--- a/models/products.js
+++ b/models/products.js
@@ -118,7 +118,7 @@ module.exports = class productModel {
                 /*
                     Searching all products
                 */
-                stmt = "SELECT * FROM products WHERE name LIKE $1;";
+                stmt = "SELECT * FROM products WHERE LOWER(name) LIKE $1;";
                 values = ['%' + this.name + '%'];
 
             } else if(this.name && this.category) {
@@ -126,7 +126,7 @@ module.exports = class productModel {
                     Search only amongst those products in the specified category
                 */
                 stmt = `SELECT p.* FROM products p INNER JOIN products_categories pc \
-                on p.product_id = pc.product_ID WHERE p.name LIKE $1 AND pc.category_id \
+                on p.product_id = pc.product_ID WHERE LOWER(p.name) LIKE $1 AND pc.category_id \
                 = $2`;
                 values = ['%' + this.name + '%', this.category];
 

--- a/routes/search.js
+++ b/routes/search.js
@@ -61,9 +61,12 @@ router.post('/', cors(), async (req, res, next) => {
 
     try{
 
-        // Create an instance of the productModel
+        /**
+         * Create an instance of the productModel and ensure
+         * that it is set to lower case
+         */
         const productModelInstance = new productModel({
-            name: terms,
+            name: terms.toLowerCase(),
             category: category
         });
 


### PR DESCRIPTION
Bith the search terms sent by the client and the products name filed need to be set to lower case so they match.

Currently, only exact matches are produced